### PR TITLE
Fix #62, #35

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ android {
 
     defaultConfig {
         applicationId "ch.epfl.polycrowd"
-        minSdkVersion 26
+        minSdkVersion 21
         targetSdkVersion 29
         versionCode 1
         versionName "1.0"

--- a/app/src/main/java/ch/epfl/polycrowd/map/MapActivity.java
+++ b/app/src/main/java/ch/epfl/polycrowd/map/MapActivity.java
@@ -1,7 +1,9 @@
 package ch.epfl.polycrowd.map;
 
+import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.AppCompatActivity;
 
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.content.Intent;
@@ -125,6 +127,7 @@ public class MapActivity extends AppCompatActivity {
     }
 
 
+    @RequiresApi(api = Build.VERSION_CODES.O)
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/app/src/main/java/ch/epfl/polycrowd/map/MapActivity.java
+++ b/app/src/main/java/ch/epfl/polycrowd/map/MapActivity.java
@@ -129,7 +129,6 @@ public class MapActivity extends AppCompatActivity {
 
     @RequiresApi(api = Build.VERSION_CODES.O)
     @Override
-    @RequiresApi(api = Build.VERSION_CODES.O)
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);


### PR DESCRIPTION
Fix #62, Fix #35
* Map activity checks logged-in user and sets level accordingly
* Also, Invite Organize button hidden for non-organizers
* FirebaseInterface.getCurrentUser() returns null if not logged in