### PR TITLE
Coverage/more tests user locator

### DIFF
--- a/app/src/androidTest/java/ch/epfl/polycrowd/frontPage/FrontPageActivityTest.java
+++ b/app/src/androidTest/java/ch/epfl/polycrowd/frontPage/FrontPageActivityTest.java
@@ -136,7 +136,12 @@ public class FrontPageActivityTest {
             onView(withId(R.id.sign_in_scroll)).check(matches(isDisplayed()));
         }
 
+    }
 
+    @Test
+    public void testUserLocatorInitialized(){
+        assert(PolyContext.getUserLocator() != null) ;
+        assert(PolyContext.getUserLocator().getConnectionId().equals( "MOCK_CONNECTION_ID")) ;
     }
 
 }

--- a/app/src/main/java/ch/epfl/polycrowd/logic/UserLocator.java
+++ b/app/src/main/java/ch/epfl/polycrowd/logic/UserLocator.java
@@ -8,7 +8,6 @@ import com.google.android.gms.maps.model.LatLng;
 
 public class UserLocator implements LocationListener {
 
-    private User registeredUser ;
     private Location location ;
     private final String connectionId ;
 
@@ -16,23 +15,11 @@ public class UserLocator implements LocationListener {
         this.connectionId  = connectionId ;
     }
 
-    public void setRegisteredUser(User registeredUser) {
-        this.registeredUser = registeredUser;
-    }
-
-    public User getRegiseredUser(){
-        return registeredUser ;
-    }
-
     @Override
     public void onLocationChanged(Location location) {
         this.location = location ;
         PolyContext.getDBI().updateUserLocation(connectionId,
                 new LatLng(this.location.getLatitude(), this.location.getLongitude()));
-
-
-        //TODO Call to the Realtime database to update the location
-        //TODO Sthg like PolyContext.getRealtimeDB().updateUserLocation(connectionId)
     }
 
     @Override
@@ -50,7 +37,8 @@ public class UserLocator implements LocationListener {
 
     }
 
-    public Location getLocation(){
-        return location ;
+    public String getConnectionId(){
+        return connectionId ;
     }
+
 }


### PR DESCRIPTION
- Checks if the UserLocator object is initialised when the FrontPageActivity is launched
- Remove unused/useless references to User field of UserLocator
- Remove unused location getter for UserLocator , since location fetching handled by realtime db
- Add a public getter for UserLocator connectionId