### PR TITLE
Coverage/firebase mocker

### DIFF
--- a/app/src/androidTest/java/ch/epfl/polycrowd/AndroidTestHelper.java
+++ b/app/src/androidTest/java/ch/epfl/polycrowd/AndroidTestHelper.java
@@ -51,9 +51,14 @@ public abstract class AndroidTestHelper {
     private static final User newUser = new User(NewUserEmail, "1", "new_fakeUser", 20);
 
 
-    private static final List<Event> ev = SetupEvents();
-    private static final Map<String, Pair<User, String>> mailAndUsersPassPair = SetupUsers();
+    private static  List<Event> ev = SetupEvents();
+    private static  Map<String, Pair<User, String>> mailAndUsersPassPair = SetupUsers();
 
+
+    public static void reset(){
+        ev = SetupEvents();
+        mailAndUsersPassPair = SetupUsers();
+    }
 
 
     private static List<Event> SetupEvents(){

--- a/app/src/androidTest/java/ch/epfl/polycrowd/account/LoginActivityOrganizerInviteTest.java
+++ b/app/src/androidTest/java/ch/epfl/polycrowd/account/LoginActivityOrganizerInviteTest.java
@@ -33,6 +33,7 @@ public class LoginActivityOrganizerInviteTest {
 
     @Before
     public void setUp() {
+        PolyContext.reset();
         AndroidTestHelper.SetupMockDBI();
         email = AndroidTestHelper.getUser().getEmail();
         pwd = AndroidTestHelper.getUserPass();
@@ -46,8 +47,10 @@ public class LoginActivityOrganizerInviteTest {
     @Test
     public void eventDetailsPageOpensAfterLoggedIn() {
         sleep();
+        sleep();
+        sleep();
         onView(withId(R.id.sign_in_email)).perform(typeText(email), closeSoftKeyboard());
-        onView(withId(R.id.sign_in_pswd)).perform(typeText(pwd));
+        onView(withId(R.id.sign_in_pswd)).perform(typeText(pwd), closeSoftKeyboard());
         onView(withId(R.id.sign_in_button)).perform(click());
         sleep();
         onView(withId(R.id.event_details_title)).check(matches(isDisplayed()));

--- a/app/src/androidTest/java/ch/epfl/polycrowd/account/LoginActivityOrganizerInviteTest.java
+++ b/app/src/androidTest/java/ch/epfl/polycrowd/account/LoginActivityOrganizerInviteTest.java
@@ -19,6 +19,7 @@ import static androidx.test.espresso.action.ViewActions.typeText;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static ch.epfl.polycrowd.AndroidTestHelper.sleep;
 
 /**
  * Tests the case when the user logs in after the organizer invite link clicked
@@ -44,9 +45,11 @@ public class LoginActivityOrganizerInviteTest {
 
     @Test
     public void eventDetailsPageOpensAfterLoggedIn() {
+        sleep();
         onView(withId(R.id.sign_in_email)).perform(typeText(email), closeSoftKeyboard());
         onView(withId(R.id.sign_in_pswd)).perform(typeText(pwd));
         onView(withId(R.id.sign_in_button)).perform(click());
+        sleep();
         onView(withId(R.id.event_details_title)).check(matches(isDisplayed()));
     }
 }

--- a/app/src/androidTest/java/ch/epfl/polycrowd/account/LoginActivityOrganizerInviteTest.java
+++ b/app/src/androidTest/java/ch/epfl/polycrowd/account/LoginActivityOrganizerInviteTest.java
@@ -34,6 +34,7 @@ public class LoginActivityOrganizerInviteTest {
     @Before
     public void setUp() {
         PolyContext.reset();
+        AndroidTestHelper.reset();
         AndroidTestHelper.SetupMockDBI();
         email = AndroidTestHelper.getUser().getEmail();
         pwd = AndroidTestHelper.getUserPass();

--- a/app/src/androidTest/java/ch/epfl/polycrowd/account/LoginActivityOrganizerInviteTest.java
+++ b/app/src/androidTest/java/ch/epfl/polycrowd/account/LoginActivityOrganizerInviteTest.java
@@ -1,0 +1,52 @@
+package ch.epfl.polycrowd.account;
+
+import android.content.Intent;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import androidx.test.rule.ActivityTestRule;
+import ch.epfl.polycrowd.AndroidTestHelper;
+import ch.epfl.polycrowd.R;
+import ch.epfl.polycrowd.authentification.LoginActivity;
+import ch.epfl.polycrowd.logic.PolyContext;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
+import static androidx.test.espresso.action.ViewActions.typeText;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+
+/**
+ * Tests the case when the user logs in after the organizer invite link clicked
+ */
+public class LoginActivityOrganizerInviteTest {
+    @Rule
+    public final ActivityTestRule<LoginActivity> loginActivityRule =
+            new ActivityTestRule<>(LoginActivity.class, false, false);
+
+    private String email, pwd;
+
+    @Before
+    public void setUp() {
+        AndroidTestHelper.SetupMockDBI();
+        email = AndroidTestHelper.getUser().getEmail();
+        pwd = AndroidTestHelper.getUserPass();
+        PolyContext.setCurrentUser(null);
+        PolyContext.setInviteRole(PolyContext.Role.ORGANIZER);
+
+        Intent intent = new Intent();
+        loginActivityRule.launchActivity(intent);
+    }
+
+    @Test
+    public void eventDetailsPageOpensAfterLoggedIn() {
+        onView(withId(R.id.sign_in_email)).perform(typeText(email), closeSoftKeyboard());
+        onView(withId(R.id.sign_in_pswd)).perform(typeText(pwd));
+        onView(withId(R.id.sign_in_button)).perform(click());
+        onView(withId(R.id.event_details_title)).check(matches(isDisplayed()));
+    }
+}

--- a/app/src/androidTest/java/ch/epfl/polycrowd/account/LoginActivitySecurityInviteTest.java
+++ b/app/src/androidTest/java/ch/epfl/polycrowd/account/LoginActivitySecurityInviteTest.java
@@ -1,0 +1,52 @@
+package ch.epfl.polycrowd.account;
+
+import android.content.Intent;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import androidx.test.rule.ActivityTestRule;
+import ch.epfl.polycrowd.AndroidTestHelper;
+import ch.epfl.polycrowd.R;
+import ch.epfl.polycrowd.authentification.LoginActivity;
+import ch.epfl.polycrowd.logic.PolyContext;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
+import static androidx.test.espresso.action.ViewActions.typeText;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static ch.epfl.polycrowd.AndroidTestHelper.sleep;
+
+public class LoginActivitySecurityInviteTest {
+    @Rule
+    public final ActivityTestRule<LoginActivity> loginActivityRule =
+            new ActivityTestRule<>(LoginActivity.class, false, false);
+
+    private String email, pwd;
+
+    @Before
+    public void setUp() {
+        PolyContext.reset();
+        AndroidTestHelper.reset();
+        AndroidTestHelper.SetupMockDBI();
+        email = AndroidTestHelper.getUser().getEmail();
+        pwd = AndroidTestHelper.getUserPass();
+        PolyContext.setCurrentUser(null);
+        PolyContext.setInviteRole(PolyContext.Role.SECURITY);
+
+        Intent intent = new Intent();
+        loginActivityRule.launchActivity(intent);
+    }
+
+    @Test
+    public void eventDetailsPageOpensAfterLoggedIn() {
+        onView(withId(R.id.sign_in_email)).perform(typeText(email), closeSoftKeyboard());
+        onView(withId(R.id.sign_in_pswd)).perform(typeText(pwd), closeSoftKeyboard());
+        onView(withId(R.id.sign_in_button)).perform(click());
+        onView(withId(R.id.event_details_title)).check(matches(isDisplayed()));
+    }
+}

--- a/app/src/androidTest/java/ch/epfl/polycrowd/account/LoginActivityTest.java
+++ b/app/src/androidTest/java/ch/epfl/polycrowd/account/LoginActivityTest.java
@@ -40,6 +40,8 @@ public class LoginActivityTest {
 
     @Before
     public void setUp() {
+        PolyContext.reset();
+        AndroidTestHelper.reset();
         AndroidTestHelper.SetupMockDBI();
 
         PolyContext.setCurrentUser(null);
@@ -85,6 +87,7 @@ public class LoginActivityTest {
     @Test
     public void testEmailFieldEmpty() {
         onView(withId(R.id.sign_in_button)).perform(click());
+        sleep();
         onView(withText("Enter your email"))
                 .inRoot(withDecorView(not(loginActivityRule.getActivity().getWindow().getDecorView())))
                 .check(matches(isDisplayed()));

--- a/app/src/androidTest/java/ch/epfl/polycrowd/flow/guestFlow.java
+++ b/app/src/androidTest/java/ch/epfl/polycrowd/flow/guestFlow.java
@@ -64,6 +64,7 @@ public class guestFlow {
         onView(withId(R.id.description)).check(matches(withText(containsString("your journey starts now !"))));
 
         onView(withId(R.id.viewPager)).perform(ViewActions.swipeLeft());
+        sleep();
         onView(withId(R.id.eventTitle)).check(matches(withText(containsString("DEBUG EVENT"))));
         onView(withId(R.id.description)).check(matches(withText(containsString("this is only a debug event ..."))));
 

--- a/app/src/androidTest/java/ch/epfl/polycrowd/flow/guestFlow.java
+++ b/app/src/androidTest/java/ch/epfl/polycrowd/flow/guestFlow.java
@@ -41,6 +41,8 @@ public class guestFlow {
 
     @Before
     public void setUp() {
+        AndroidTestHelper.reset();
+        PolyContext.reset();
         AndroidTestHelper.SetupMockDBI();
         PolyContext.setCurrentUser(null);
 

--- a/app/src/androidTest/java/ch/epfl/polycrowd/flow/guestFlow.java
+++ b/app/src/androidTest/java/ch/epfl/polycrowd/flow/guestFlow.java
@@ -59,6 +59,7 @@ public class guestFlow {
         onView(withId(R.id.button)).check(matches(withText(containsString("LOGIN"))));
 
         onView(withId(R.id.viewPager)).perform(ViewActions.swipeRight());
+        sleep();
         onView(withId(R.id.eventTitle)).check(matches(withText(containsString("Create an EVENT"))));
         onView(withId(R.id.description)).check(matches(withText(containsString("your journey starts now !"))));
 

--- a/app/src/androidTest/java/ch/epfl/polycrowd/flow/visitorFlow.java
+++ b/app/src/androidTest/java/ch/epfl/polycrowd/flow/visitorFlow.java
@@ -40,6 +40,7 @@ public class visitorFlow {
 
     @Before
     public void setUp() {
+        PolyContext.reset();
         AndroidTestHelper.SetupMockDBI();
         PolyContext.setCurrentUser(AndroidTestHelper.getUser());
 

--- a/app/src/androidTest/java/ch/epfl/polycrowd/flow/visitorFlow.java
+++ b/app/src/androidTest/java/ch/epfl/polycrowd/flow/visitorFlow.java
@@ -77,6 +77,7 @@ public class visitorFlow {
         sleep();
         onView(withId(R.id.map)).check(matches(isDisplayed()));
         onView(withId(R.id.butRight)).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)));
+        sleep();
         onView(withId(R.id.butRight)).check(matches(withText(containsString("EVENT DETAILS"))));
         onView(withId(R.id.butLeft)).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)));
         onView(withId(R.id.butLeft)).check(matches(withText(containsString("GROUPS"))));
@@ -132,6 +133,7 @@ public class visitorFlow {
         onView(withId(R.id.organizers_recycler_view)).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)));
         onView(withId(R.id.invite_organizer_button)).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.INVISIBLE)));
 
+        sleep();
         onView(withId(R.id.EditEventSecurity)).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.GONE)));
         onView(withId(R.id.security_scroll)).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)));
         onView(withId(R.id.security_recycler_view)).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)));
@@ -139,6 +141,7 @@ public class visitorFlow {
 
         onView(withId(R.id.event_details_submit)).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.INVISIBLE)));
         onView(withId(R.id.event_details_cancel)).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.INVISIBLE)));
+        sleep();
         onView(withId(R.id.event_details_fab)).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.GONE)));
 
         onView(withId(R.id.schedule)).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)));
@@ -210,6 +213,8 @@ public class visitorFlow {
     public void testEmergencyPage() {
         onView(withId(R.id.viewPager)).perform(ViewActions.click());
 
+        sleep();
+        onView(withId(R.id.butSOS)).perform(ViewActions.scrollTo());
         onView(withId(R.id.butSOS)).perform(ViewActions.click());
         onView(withId(R.id.butSOS)).perform(ViewActions.longClick());
         sleep();

--- a/app/src/androidTest/java/ch/epfl/polycrowd/flow/visitorFlow.java
+++ b/app/src/androidTest/java/ch/epfl/polycrowd/flow/visitorFlow.java
@@ -71,6 +71,7 @@ public class visitorFlow {
 
     @Test
     public void testMapViewEventPage() {
+        sleep();
         onView(withId(R.id.viewPager)).perform(ViewActions.click());
         sleep();
         onView(withId(R.id.map)).check(matches(isDisplayed()));
@@ -85,6 +86,7 @@ public class visitorFlow {
 
     @Test
     public void testEventPage() {
+        sleep();
         onView(withId(R.id.viewPager)).perform(ViewActions.click());
         onView(withId(R.id.butRight)).perform(ViewActions.click());
         sleep();

--- a/app/src/androidTest/java/ch/epfl/polycrowd/flow/visitorFlow.java
+++ b/app/src/androidTest/java/ch/epfl/polycrowd/flow/visitorFlow.java
@@ -216,7 +216,7 @@ public class visitorFlow {
         onView(withId(R.id.viewPager)).perform(ViewActions.click());
 
         sleep();
-        onView(withId(R.id.butSOS)).perform(ViewActions.scrollTo());
+        //onView(withId(R.id.butSOS)).perform(ViewActions.scrollTo());
 
         onView(withId(R.id.butSOS)).perform(ViewActions.click());
         onView(withId(R.id.butSOS)).perform(ViewActions.longClick());

--- a/app/src/androidTest/java/ch/epfl/polycrowd/flow/visitorFlow.java
+++ b/app/src/androidTest/java/ch/epfl/polycrowd/flow/visitorFlow.java
@@ -41,8 +41,9 @@ public class visitorFlow {
     @Before
     public void setUp() {
         PolyContext.reset();
+        AndroidTestHelper.reset();
         AndroidTestHelper.SetupMockDBI();
-        PolyContext.setCurrentUser(AndroidTestHelper.getUser());
+        PolyContext.setCurrentUser(AndroidTestHelper.getUser("USER@h.net"));
 
         Intent intent = new Intent();
         frontPageActivityRule.launchActivity(intent);
@@ -74,7 +75,8 @@ public class visitorFlow {
     public void testMapViewEventPage() {
         sleep();
         onView(withId(R.id.viewPager)).perform(ViewActions.click());
-        sleep();
+
+            sleep();
         onView(withId(R.id.map)).check(matches(isDisplayed()));
         onView(withId(R.id.butRight)).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)));
         onView(withId(R.id.butRight)).check(matches(withText(containsString("EVENT DETAILS"))));
@@ -209,7 +211,8 @@ public class visitorFlow {
     @Test
     public void testEmergencyPage() {
         onView(withId(R.id.viewPager)).perform(ViewActions.click());
-
+        sleep();
+        sleep();
         onView(withId(R.id.butSOS)).perform(ViewActions.click());
         onView(withId(R.id.butSOS)).perform(ViewActions.longClick());
         sleep();

--- a/app/src/androidTest/java/ch/epfl/polycrowd/frontPage/FrontPageOrganizerInviteTest.java
+++ b/app/src/androidTest/java/ch/epfl/polycrowd/frontPage/FrontPageOrganizerInviteTest.java
@@ -1,0 +1,53 @@
+package ch.epfl.polycrowd.frontPage;
+
+import android.Manifest;
+import android.content.Intent;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.rule.GrantPermissionRule;
+import ch.epfl.polycrowd.AndroidTestHelper;
+import ch.epfl.polycrowd.R;
+import ch.epfl.polycrowd.logic.PolyContext;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static ch.epfl.polycrowd.AndroidTestHelper.getDebugEvent;
+import static ch.epfl.polycrowd.AndroidTestHelper.sleep;
+
+public class FrontPageOrganizerInviteTest {
+
+    @Rule
+    public final ActivityTestRule<FrontPageActivity> frontPageActivityRule =
+            new ActivityTestRule<>(FrontPageActivity.class, true, false);
+
+
+    @Rule
+    public GrantPermissionRule grantFineLocation =
+            GrantPermissionRule.grant(Manifest.permission.ACCESS_FINE_LOCATION);
+
+    @Before
+    public void setUp() {
+        AndroidTestHelper.reset();
+        PolyContext.reset();
+//        AndroidTestHelper.SetupMockDBI();
+        AndroidTestHelper.SetupMockDBI("https://www.example.com/inviteORGANIZER/?eventId="+"1"+"&eventName="+"DEBUG_EVENT");
+//        PolyContext.setInviteRole(PolyContext.Role.ORGANIZER);
+        PolyContext.setCurrentEvent(getDebugEvent());
+        PolyContext.setCurrentUser(null);
+
+        // launch the intent
+        Intent intent = new Intent();
+        frontPageActivityRule.launchActivity(intent);
+    }
+
+    @Test
+    public void invitePageDisplaysWhenOrganizerInviteReceived() {
+        onView(withId(R.id.member_invite_text)).check(matches(isDisplayed()));
+    }
+}

--- a/app/src/androidTest/java/ch/epfl/polycrowd/frontPage/FrontPageOrganizerInviteTest.java
+++ b/app/src/androidTest/java/ch/epfl/polycrowd/frontPage/FrontPageOrganizerInviteTest.java
@@ -22,32 +22,32 @@ import static ch.epfl.polycrowd.AndroidTestHelper.sleep;
 
 public class FrontPageOrganizerInviteTest {
 
-    @Rule
-    public final ActivityTestRule<FrontPageActivity> frontPageActivityRule =
-            new ActivityTestRule<>(FrontPageActivity.class, true, false);
-
-
-    @Rule
-    public GrantPermissionRule grantFineLocation =
-            GrantPermissionRule.grant(Manifest.permission.ACCESS_FINE_LOCATION);
-
-    @Before
-    public void setUp() {
-        AndroidTestHelper.reset();
-        PolyContext.reset();
-//        AndroidTestHelper.SetupMockDBI();
-        AndroidTestHelper.SetupMockDBI("https://www.example.com/inviteORGANIZER/?eventId="+"1"+"&eventName="+"DEBUG_EVENT");
-//        PolyContext.setInviteRole(PolyContext.Role.ORGANIZER);
-        PolyContext.setCurrentEvent(getDebugEvent());
-        PolyContext.setCurrentUser(null);
-
-        // launch the intent
-        Intent intent = new Intent();
-        frontPageActivityRule.launchActivity(intent);
-    }
-
-    @Test
-    public void invitePageDisplaysWhenOrganizerInviteReceived() {
-        onView(withId(R.id.member_invite_text)).check(matches(isDisplayed()));
-    }
+//    @Rule
+//    public final ActivityTestRule<FrontPageActivity> frontPageActivityRule =
+//            new ActivityTestRule<>(FrontPageActivity.class, true, false);
+//
+//
+//    @Rule
+//    public GrantPermissionRule grantFineLocation =
+//            GrantPermissionRule.grant(Manifest.permission.ACCESS_FINE_LOCATION);
+//
+//    @Before
+//    public void setUp() {
+//        AndroidTestHelper.reset();
+//        PolyContext.reset();
+////        AndroidTestHelper.SetupMockDBI();
+//        AndroidTestHelper.SetupMockDBI("https://www.example.com/inviteORGANIZER/?eventId="+"1"+"&eventName="+"DEBUG_EVENT");
+////        PolyContext.setInviteRole(PolyContext.Role.ORGANIZER);
+//        PolyContext.setCurrentEvent(getDebugEvent());
+//        PolyContext.setCurrentUser(null);
+//
+//        // launch the intent
+//        Intent intent = new Intent();
+//        frontPageActivityRule.launchActivity(intent);
+//    }
+//
+//    @Test
+//    public void invitePageDisplaysWhenOrganizerInviteReceived() {
+//        onView(withId(R.id.member_invite_text)).check(matches(isDisplayed()));
+//    }
 }

--- a/app/src/main/java/ch/epfl/polycrowd/eventMemberInvite/EventMemberInviteActivity.java
+++ b/app/src/main/java/ch/epfl/polycrowd/eventMemberInvite/EventMemberInviteActivity.java
@@ -36,6 +36,7 @@ public class EventMemberInviteActivity extends AppCompatActivity {
                 return;
         }
         if(PolyContext.getCurrentEvent() == null) {
+            Log.d(TAG, "current event is null");
             ActivityHelper.eventIntentHandler(this, FrontPageActivity.class);
             return;
         }

--- a/app/src/main/java/ch/epfl/polycrowd/eventMemberInvite/EventMemberInviteActivity.java
+++ b/app/src/main/java/ch/epfl/polycrowd/eventMemberInvite/EventMemberInviteActivity.java
@@ -36,7 +36,6 @@ public class EventMemberInviteActivity extends AppCompatActivity {
                 return;
         }
         if(PolyContext.getCurrentEvent() == null) {
-            Log.d(TAG, "current event is null");
             ActivityHelper.eventIntentHandler(this, FrontPageActivity.class);
             return;
         }

--- a/app/src/main/java/ch/epfl/polycrowd/firebase/FirebaseMocker.java
+++ b/app/src/main/java/ch/epfl/polycrowd/firebase/FirebaseMocker.java
@@ -162,7 +162,6 @@ public class FirebaseMocker implements DatabaseInterface {
     public void receiveDynamicLink(Handler<Uri> handler, Intent intent) {
         if(uriString != null) {
             Uri uri = Uri.parse(uriString);
-            Log.d(TAG, "dynamic link parsed");
             handler.handle(uri);
         }
     }

--- a/app/src/main/java/ch/epfl/polycrowd/firebase/FirebaseMocker.java
+++ b/app/src/main/java/ch/epfl/polycrowd/firebase/FirebaseMocker.java
@@ -27,6 +27,8 @@ import ch.epfl.polycrowd.logic.Message;
 import ch.epfl.polycrowd.logic.PolyContext;
 import ch.epfl.polycrowd.logic.User;
 
+import static java.lang.Thread.sleep;
+
 @RequiresApi(api = Build.VERSION_CODES.O)
 public class FirebaseMocker implements DatabaseInterface {
 
@@ -160,6 +162,7 @@ public class FirebaseMocker implements DatabaseInterface {
     public void receiveDynamicLink(Handler<Uri> handler, Intent intent) {
         if(uriString != null) {
             Uri uri = Uri.parse(uriString);
+            Log.d(TAG, "dynamic link parsed");
             handler.handle(uri);
         }
     }

--- a/app/src/main/java/ch/epfl/polycrowd/frontPage/FrontPageActivity.java
+++ b/app/src/main/java/ch/epfl/polycrowd/frontPage/FrontPageActivity.java
@@ -216,13 +216,6 @@ public class FrontPageActivity extends AppCompatActivity {
         if (eventId != null && eventName != null) {
             PolyContext.getDBI().getEventById(eventId, event -> {
                 PolyContext.setCurrentEvent(event);
-                /*
-                Log.d(TAG, "handling geteventbyid, role: " + role.toString());
-                if(PolyContext.getCurrentEvent() == null) {
-                    Log.d(TAG, "cur event is null");
-                } else {
-                    Log.d(TAG, "current event is not null");
-                } */
                 PolyContext.setInviteRole(role);
                 ActivityHelper.eventIntentHandler(c, EventMemberInviteActivity.class);
             });

--- a/app/src/main/java/ch/epfl/polycrowd/frontPage/FrontPageActivity.java
+++ b/app/src/main/java/ch/epfl/polycrowd/frontPage/FrontPageActivity.java
@@ -188,7 +188,7 @@ public class FrontPageActivity extends AppCompatActivity {
     // --------- Link --------------------------------------------------------------------
     private void receiveDynamicLink() {
         PolyContext.getDBI().receiveDynamicLink(deepLink -> {
-            Log.d(TAG, "Deep link URL:\n" + deepLink.toString());
+            Log.d(TAG, "handling the dynamic link");
             String lastPathSegment = deepLink.getLastPathSegment();
             if(lastPathSegment == null)
                 return;
@@ -212,9 +212,17 @@ public class FrontPageActivity extends AppCompatActivity {
     private static void inviteEventMemberDynamicLink(Context c, Uri deepLink, PolyContext.Role role){
         String eventId = deepLink.getQueryParameter("eventId"),
                 eventName = deepLink.getQueryParameter("eventName");
+        Log.d(TAG, "event id: " + eventId);
         if (eventId != null && eventName != null) {
             PolyContext.getDBI().getEventById(eventId, event -> {
                 PolyContext.setCurrentEvent(event);
+                /*
+                Log.d(TAG, "handling geteventbyid, role: " + role.toString());
+                if(PolyContext.getCurrentEvent() == null) {
+                    Log.d(TAG, "cur event is null");
+                } else {
+                    Log.d(TAG, "current event is not null");
+                } */
                 PolyContext.setInviteRole(role);
                 ActivityHelper.eventIntentHandler(c, EventMemberInviteActivity.class);
             });

--- a/app/src/main/java/ch/epfl/polycrowd/logic/PolyContext.java
+++ b/app/src/main/java/ch/epfl/polycrowd/logic/PolyContext.java
@@ -34,8 +34,14 @@ public abstract class PolyContext extends Context {
     public static void reset(){
         currentEvent = null;
         currentUser = null;
+        currentGroup = null;
         inviteRole = Role.UNKNOWN;
+        groupId = null;
         previousPage = null;
+        standId = null;
+        dbInterface  = new FirebaseInterface() ;
+        userLocator = null ;
+        userGroupList = null ;
     }
   
     public static String getStandId() {


### PR DESCRIPTION
Some more test improving the coverage of the `FirebaseMocker`  and `LoginActivity`.  
Two tests classes added to test the `LoginActivity` for the invites handling.   
Some methods of the `FirebaseMocker` are still not tested: the method for removing an organizer from the organizer list (the __revoke__ button is not displayed) and the method for receiving the dynamic link (for some reason the current event is reset to null when switching from the front page to the invite page)